### PR TITLE
fix typo in inclue Ram.h

### DIFF
--- a/src/VM.h
+++ b/src/VM.h
@@ -24,7 +24,7 @@
 
 #include "Config.h"
 #include "CPU.h"
-#include "RAM.h"
+#include "Ram.h"
 #include "Ports.h"
 #include "PIT.h"
 #include "PIC.h"


### PR DESCRIPTION
First, thank you for the great work. This Pr fix typo in VM.h including "Ram.h", this fix compile issue on Linux since Linux has case-sensitive filename.

